### PR TITLE
v0.6.1 / v0.6.2 merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 This adapter polls information from SNMP Device like Printers, Network ...
 
 ## Changelog
+### 0.6.2
+* (McM1957) rename state IP.info.connected to IP.online
+
 ### 0.6.1
 * (McM1957) reduce severity of timout message to informational
 * (McM1957) reduce latency for update of info.connection 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@
 This adapter polls information from SNMP Device like Printers, Network ...
 
 ## Changelog
-### 0.6.0
-* (mcm1957) avoid excessive error logs if target is unreachable
-* (mcm1957) add additional info.connection at ip base to indicate target is reachable
-* (mcm1957) output warning if OIDs specify different commmunities for one device
+### 0.6.1
+* (McM1957) reduce severity of timout message to informational
+* (McM1957) reduce letency for update of info.connection 
 
+### 0.6.0
+* (McM1957) avoid excessive error logs if target is unreachable
+* (McM1957) add additional info.connection at ip base to indicate target is reachable
+* (McM1957) output warning if OIDs specify different commmunities for one device
 
 ### 0.5.0
 * (Marcolotti) Add documentation (de,en,ru)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This adapter polls information from SNMP Device like Printers, Network ...
 ### 0.6.1
 * (McM1957) reduce severity of timout message to informational
 * (McM1957) reduce latency for update of info.connection 
+* (McM1957) update dependencies as suggested by dependabot
 
 ### 0.6.0
 * (McM1957) avoid excessive error logs if target is unreachable

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This adapter polls information from SNMP Device like Printers, Network ...
 ## Changelog
 ### 0.6.1
 * (McM1957) reduce severity of timout message to informational
-* (McM1957) reduce letency for update of info.connection 
+* (McM1957) reduce latency for update of info.connection 
 
 ### 0.6.0
 * (McM1957) avoid excessive error logs if target is unreachable

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 This adapter polls information from SNMP Device like Printers, Network ...
 
 ## Changelog
+### 0.6.0
+* (mcm1957) avoid excessive error logs if target is unreachable
+* (mcm1957) add additional info.connection at ip base to indicate target is reachable
+* (mcm1957) output warning if OIDs specify different commmunities for one device
+
+
 ### 0.5.0
 * (Marcolotti) Add documentation (de,en,ru)
 * (Marcolotti) Add languages (de,en,ru)

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "snmp",
-        "version": "0.5.0",
+        "version": "0.6.0-beta",
         "news": {
             "0.0.1": {
                 "en": "initial adapter",

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "snmp",
-        "version": "0.6.1-beta",
+        "version": "0.6.1",
         "news": {
             "0.0.1": {
                 "en": "initial adapter",
@@ -10,6 +10,18 @@
                 "pt": "Versão inicial",
                 "fr": "Version initiale",
                 "nl": "Eerste release"
+            },
+            "0.6.1": {
+				"en": "improved handling of offline devices",
+				"de": "verbesserte Handhabung von Offline-Geräten",
+				"ru": "улучшенная обработка автономных устройств",
+				"pt": "melhor manuseio de dispositivos offline",
+				"nl": "verbeterde verwerking van offline apparaten",
+				"fr": "gestion améliorée des appareils hors ligne",
+				"it": "migliore gestione dei dispositivi offline",
+				"es": "manejo mejorado de dispositivos fuera de línea",
+				"pl": "ulepszona obsługa urządzeń offline",
+				"zh-cn": "改进了对离线设备的处理"
             }
         },
         "title": "SNMP Adapter",
@@ -23,7 +35,6 @@
         },
         "license": "MIT",
         "platform": "Javascript/Node.js",
-        "mode": "daemon",
         "icon": "snmp.png",
         "extIcon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
 	    "keywords": [
@@ -31,7 +42,10 @@
         ],
         "readme": "https://github.com/iobroker-community-adapters/ioBroker.snmp/blob/master/README.md",
         "loglevel": "info",
+        "mode": "daemon",
         "type": "infrastructure",
+		"connectionType": "local",
+		"dataSource": "poll",
         "restartAdapters": [],
         "authors": [
             {
@@ -46,9 +60,9 @@
         "pollInterval": 30000,
         "OIDs": [
             {
-                "ip": "192.168.178.48",
-                "name": "Samsung CLP320",
-                "OID": "1.3.6.1.2.1.43.11.1.1.9.1.1"
+                "ip": "127.0.0.1",
+                "name": "system.description",
+                "OID": ".1.3.6.1.2.1.1.1.0"
             }
         ]
     },

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "snmp",
-        "version": "0.6.1",
+        "version": "0.6.2",
         "news": {
             "0.0.1": {
                 "en": "initial adapter",
@@ -22,7 +22,19 @@
 				"es": "manejo mejorado de dispositivos fuera de línea",
 				"pl": "ulepszona obsługa urządzeń offline",
 				"zh-cn": "改进了对离线设备的处理"
-            }
+            },
+            "0.6.2": {
+				"en": "renamed IP.info.connected to IP.online",
+				"de": "umbenannt in IP.info.connected in IP.online",
+				"ru": "переименован в IP.info.подключен к IP.online",
+				"pt": "renomeado IP.info.connected para IP.online",
+				"nl": "hernoemd IP.info.verbonden met IP.online",
+				"fr": "renommé IP.info.connected en IP.online",
+				"it": "rinominato IP.info.connected a IP.online",
+				"es": "renombrado IP.info.conectado a IP.online",
+				"pl": "zmieniono nazwę IP.info.połączone z IP.online",
+				"zh-cn": "将 IP.info.connected 重命名为 IP.online"
+ 			}
         },
         "title": "SNMP Adapter",
         "desc": {

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "snmp",
-        "version": "0.6.0-beta",
+        "version": "0.6.1-beta",
         "news": {
             "0.0.1": {
                 "en": "initial adapter",

--- a/main.js
+++ b/main.js
@@ -2,6 +2,13 @@
  *
  * snmp adapter, Copyright CTJaeger 2017, MIT
  *
+ * changelog:
+ *
+ * 2022-02-18 	mcm1957		add info.connection state per ip 
+ *							avoid excessive errors if target is unreachable
+ *							improve setting of state info.connection
+ *							output warning if OIDs specify different commmunities for one device
+ *
  */
 
 /* jshint -W097 */
@@ -15,10 +22,14 @@ var snmp    = require('net-snmp');
 
 var adapter = new utils.Adapter('snmp');
 var IPs = {};
+var myData = {};
 
+myData.connected = false;
+
+// startup 
 adapter.on('ready', main);
 
-// close all opened sockets
+// shutdown - close all opened sockets
 adapter.on('unload', function (callback) {
     for (var ip in IPs) {
         if (IPs.hasOwnProperty(ip) && IPs[ip].session) {
@@ -30,6 +41,16 @@ adapter.on('unload', function (callback) {
             IPs[ip].session = null;
         }
     }
+	
+	if (myData.interval) {
+		try {
+			clearInterval(myData.interval);
+		} catch (e) {
+
+		}
+		myData.interval = null;
+	}
+	
     callback && callback();
 });
 
@@ -74,6 +95,8 @@ function main() {
         adapter.config.pollInterval = 5000;
     }
 
+	adapter.setState('info.connection', false, true);
+
     var tasks = [];
     for (var i = 0; i < adapter.config.OIDs.length; i++) {
         if (!adapter.config.OIDs[i].ip || !adapter.config.OIDs[i].enabled) {
@@ -87,6 +110,14 @@ function main() {
 
         IPs[ip].oids.push(adapter.config.OIDs[i].OID.trim().replace(/^\./, ''));
         IPs[ip].ids.push(id);
+		IPs[ip].inactive = false;
+
+		// verify that all OIDs specifiy identical community for same device (same ip)
+		if ( IPs[ip].publicCom != adapter.config.OIDs[i].publicCom ) {
+			adapter.log.warn('[' + ip + '] OID ' + adapter.config.OIDs[i].OID.trim().replace(/^\./, '') + 
+				' specifies different community "' + adapter.config.OIDs[i].publicCom + '"');
+			adapter.log.warn('[' + ip + '] value will be ignored, keeping current value "' + IPs[ip].publicCom + '"');
+		}
 
         var IPString = ip.replace(/\./gi, "_");
 
@@ -103,6 +134,36 @@ function main() {
                 OID: adapter.config.OIDs[i].OID
             }
         });
+		
+        tasks.push({
+            _id: adapter.namespace + '.' + IPString + '.info',
+            type: 'channel',
+            common: {
+                name:  'device information',
+                //write: !!adapter.config.OIDs[i].write,
+                read:  true,
+                role: 'value'
+            },
+            native: {
+                OID: adapter.config.OIDs[i].OID
+            }
+        });
+		
+		tasks.push({
+            _id: adapter.namespace + '.' + IPString + '.info.connection',
+            type: 'state',
+            common: {
+                name:  'If device is connected',
+                //write: !!adapter.config.OIDs[i].write,
+                read:  true,
+                type: 'boolean',
+                role: 'value'
+            },
+            native: {
+                OID: adapter.config.OIDs[i].OID
+            }
+        });
+
 		tasks.push({
             _id: adapter.namespace + '.' + IPString + '.' + id,
             type: 'state',
@@ -119,20 +180,68 @@ function main() {
         });
     }
     processTasks(tasks, readAll);
+	
+    myData.interval = setInterval(handleConnectionInfo, adapter.config.pollInterval);
 }
+
+function handleConnectionInfo() {
+	var connected = false;
+
+	adapter.log.debug('executing handleConnectionInfo');
+	
+    for (var ip in IPs) {
+		if (! IPs[ip].inactive)  {
+			connected = true;
+		}
+	}
+	adapter.setState('info.connection', connected, true);
+	if ( connected ) {
+		if ( ! myData.connected ) {
+			adapter.log.info('instance connected to at least one device');
+			myData.connected = true;
+		}
+	} else  {
+		if ( myData.connected ) {
+			adapter.log.info('instance disconnected from all devices');
+			myData.connected = false;
+		}
+	}
+}
+
 function readOids(session, ip, oids, ids) {
+	adapter.log.debug('[' + ip + '] executing readOids');
+
     session.get(oids, function (error, varbinds) {
             if (error) {
-                adapter.log.error('[' + ip + '] Error session.get: ' + error);
+				adapter.log.debug('[' + ip + '] session.get: ' + error);
+				if (error == 'RequestTimedOutError: Request timed out') {
+					if ( ! IPs[ip].inactive ) {
+						adapter.log.warn('[' + ip + '] device disconnected - request timout');
+						IPs[ip].inactive = true;
+					};
+				} else {
+					if ( ! IPs[ip].inactive ) {
+						adapter.log.error('[' + ip + '] session.get: ' +error);
+						IPs[ip].inactive = true;0
+					};
+					adapter.setState(ip.replace(/\./gi, "_") + '.info.connection', false, true);
+				}
             } else {
-                for (var i = 0; i < varbinds.length; i++) {
-                   if (snmp.isVarbindError(varbinds[i])) {
+				if ( IPs[ip].inactive ) {
+					adapter.log.info('[' + ip + '] device (re)connected');
+					IPs[ip].inactive = false;
+				};
+				
+				adapter.setState(ip.replace(/\./gi, "_") + '.info.connection', true, true);
+                
+				for (var i = 0; i < varbinds.length; i++) {
+					if (snmp.isVarbindError(varbinds[i])) {
                         adapter.log.warn(snmp.varbindError(varbinds[i]));
                         adapter.setState(ip.replace(/\./gi, "_") + '.' +ids[i], null, true, 0x84);
                     } else {
-                        adapter.log.debug(ip.replace(/\./gi, "_") + '.' +ids[i]);
+						adapter.log.debug('[' + ip + '] update ' + ip.replace(/\./gi, "_") + '.' +ids[i]);
                         adapter.setState(ip.replace(/\./gi, "_") + '.' +ids[i], varbinds[i].value.toString(), true);
-                        adapter.setState('info.connection', true, true);
+                        // adapter.setState('info.connection', true, true); 
                     }
                 }
             }
@@ -140,10 +249,11 @@ function readOids(session, ip, oids, ids) {
 }
 
 function readOneDevice(ip, publicCom, oids, ids) {
+	adapter.log.debug('executing readOneDevice (' + ip + ', ...)');
     if (IPs[ip].session) {
         try {
             IPs[ip].session.close();
-            adapter.setState('info.connection', false, true);
+//            adapter.setState('info.connection', false, true);
         } catch (e) {
             adapter.log.warn('Cannot close session: ' + e);
         }
@@ -169,6 +279,7 @@ function readOneDevice(ip, publicCom, oids, ids) {
 }
 
 function readAll() {
+	adapter.log.debug('executing readAll');
     for (var ip in IPs) {
         if (IPs.hasOwnProperty(ip))  {
             readOneDevice(ip, IPs[ip].publicCom, IPs[ip].oids, IPs[ip].ids);

--- a/main.js
+++ b/main.js
@@ -14,6 +14,9 @@
  *		reduce timout warning to info level
  *		reduce latency for update of info.connection
  *
+ * 2022-03-15 	McM1957	 0.6.2
+ *		rename IP.info.connection state to IP.online 
+ *
  */
 
 /* jshint -W097 */
@@ -45,7 +48,7 @@ adapter.on('unload', function (callback) {
             }
             IPs[ip].session = null;
         }
-		adapter.setState(ip.replace(/\./gi, "_") + '.info.connection', false, true);
+		adapter.setState(ip.replace(/\./gi, "_") + '.online', false, true);
     }
 	
 	if (myData.interval) {
@@ -159,10 +162,10 @@ function main() {
         });
 		
 		tasks.push({
-            _id: adapter.namespace + '.' + IPString + '.info.connection',
+            _id: adapter.namespace + '.' + IPString + '.online',
             type: 'state',
             common: {
-                name:  'If device is connected',
+                name:  'device online',
                 //write: !!adapter.config.OIDs[i].write,
                 read:  true,
                 type: 'boolean',
@@ -236,7 +239,7 @@ function readOids(session, ip, oids, ids) {
 						IPs[ip].inactive = true;
 						setImmediate(handleConnectionInfo);
 					};
-					adapter.setState(ip.replace(/\./gi, "_") + '.info.connection', false, true);
+					adapter.setState(ip.replace(/\./gi, "_") + '.online', false, true);
 				}
             } else {
 				if ( IPs[ip].inactive ) {
@@ -245,7 +248,7 @@ function readOids(session, ip, oids, ids) {
 					setImmediate(handleConnectionInfo);
 				};
 
-				adapter.setState(ip.replace(/\./gi, "_") + '.info.connection', true, true);
+				adapter.setState(ip.replace(/\./gi, "_") + '.online', true, true);
                 
 				for (var i = 0; i < varbinds.length; i++) {
 					if (snmp.isVarbindError(varbinds[i])) {
@@ -279,7 +282,7 @@ function readOneDevice(ip, publicCom, oids, ids) {
     }
 
 	// initialize connection status
-	adapter.setState(ip.replace(/\./gi, "_") + '.info.connection', false, true);
+	adapter.setState(ip.replace(/\./gi, "_") + '.online', false, true);
 
 	// create snmp session for device
     IPs[ip].session = snmp.createSession(ip, publicCom || 'public', {

--- a/main.js
+++ b/main.js
@@ -147,20 +147,6 @@ function main() {
             }
         });
 		
-        tasks.push({
-            _id: adapter.namespace + '.' + IPString + '.info',
-            type: 'channel',
-            common: {
-                name:  'device information',
-                //write: !!adapter.config.OIDs[i].write,
-                read:  true,
-                role: 'value'
-            },
-            native: {
-                OID: adapter.config.OIDs[i].OID
-            }
-        });
-		
 		tasks.push({
             _id: adapter.namespace + '.' + IPString + '.online',
             type: 'state',

--- a/main.js
+++ b/main.js
@@ -4,10 +4,11 @@
  *
  * changelog:
  *
- * 2022-02-18 	mcm1957		add info.connection state per ip 
- *							avoid excessive errors if target is unreachable
- *							improve setting of state info.connection
- *							output warning if OIDs specify different commmunities for one device
+ * 2022-02-18 	mcm1957	
+ *		add info.connection state per ip 
+ *		avoid excessive errors if target is unreachable
+ *		improve setting of state info.connection
+ *		output warning if OIDs specify different commmunities for one device
  *
  */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.snmp",
-  "version": "0.6.1-beta",
+  "version": "0.6.1",
   "description": "ioBroker SNMP Adapter",
   "author": {
     "name": "Marcolotti",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.snmp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "ioBroker SNMP Adapter",
   "author": {
     "name": "Marcolotti",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.snmp",
-  "version": "0.6.0-beta",
+  "version": "0.6.1-beta",
   "description": "ioBroker SNMP Adapter",
   "author": {
     "name": "Marcolotti",
@@ -10,7 +10,12 @@
     {
       "name": "Marcolotti",
       "email": "info@ct-j.de"
+    },
+	{
+      "name": "McM1957",
+      "email": "mcm57@gmx.at"
     }
+
   ],
   "homepage": "https://github.com/iobroker-community-adapters/ioBroker.snmp",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.snmp",
-  "version": "0.5.0",
+  "version": "0.6.0-beta",
   "description": "ioBroker SNMP Adapter",
   "author": {
     "name": "Marcolotti",


### PR DESCRIPTION
The following changes / improvements are included in this pull request:

### 0.6.2
* (McM1957) rename state IP.info.connected to IP.online

### 0.6.1
* (McM1957) reduce severity of timout message to informational
* (McM1957) reduce latency for update of info.connection 
* (McM1957) update dependencies as suggested by dependabot

### 0.6.0
* (McM1957) avoid excessive error logs if target is unreachable
* (McM1957) add additional info.connection at ip base to indicate target is reachable
* (McM1957) output warning if OIDs specify different commmunities for one device

