### PR TITLE
Don't lose invalid utf8 characters while converting OctetString data

### DIFF
--- a/main.js
+++ b/main.js
@@ -555,7 +555,11 @@ function processVarbind(pCTX, pChunkIdx, pId, pIdx, pVarbind) {
         }
         case snmp.ObjectType.OctetString:{
             valTypeStr = 'OctetString';
-            valStr = pVarbind.value.toString();
+            if (isValidUTF8Buffer(pVarbind.value)) {
+                valStr = pVarbind.value.toString();
+            } else {
+                valStr = JSON.stringify(pVarbind.value);
+          	}
             break;
         }
         case snmp.ObjectType.Null:{
@@ -789,6 +793,11 @@ function handleConnectionInfo() {
         adapter.setState('info.connection', g_isConnected, true);
     }
 }
+
+function isValidUTF8Buffer(buf){
+    return Buffer.compare(new Buffer(buf.toString(),'utf8') , buf) === 0;
+}
+
 
 /**
  * validateConfig - scan and validate config data


### PR DESCRIPTION
Binary data is forcibly converted to utf-8, replacing illegal UTF8 characters with utf8 "invalid character" symbol which destroys binary data. With this fix it is first tested if the conversion is valid. If it is invalid, the buffer is instead converted to JSON representation which can be converted back to original buffer by a script and handled depending on the individual data.
